### PR TITLE
Fix for hint foreground color

### DIFF
--- a/themes/one-dark-pro-max.json
+++ b/themes/one-dark-pro-max.json
@@ -108,7 +108,7 @@
         "hidden": null,
         "hidden.background": null,
         "hidden.border": null,
-        "hint": "#080909",
+        "hint": "#788ca6ff",
         "hint.background": "#080909",
         "hint.border": "#013b64",
         "ignored": "#636b78",


### PR DESCRIPTION
Fix for this issue: https://github.com/bukitoka/one-dark-pro-max/issues/1#issue-3624554945